### PR TITLE
respect write permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,14 @@ and should be fixed in v3.3.3 with the inclusion of `GroupExternalAuthNCheck Off
 	    GroupExternal svn-auth
 	    <RequireAll>
 		    Require valid-user
-		    <Limit GET>
+		    <Limit GET HEAD OPTIONS REPORT>
 			    Require external-group svn-authz authz:read
 		    </Limit>
-		    <Limit POST>
+		    <Limit POST PUT PROPPATCH>
 			    Require external-group svn-authz authz:write
+		    </Limit>
+		    <Limit MERGE DELETE>
+		        Require valid-user
 		    </Limit>
 	    </RequireAll>
     </Location>

--- a/svn-auth.php
+++ b/svn-auth.php
@@ -27,6 +27,8 @@ $svn_path = preg_replace('/'.preg_quote($SVNLocationPath, '/').'/', $SVNParentPa
 // for folder reads it queries each item with !svn/ver/{revision}/ inserted into the path
 $svn_path = preg_replace('/!svn\/ver\/\d+\//', '', $svn_path);
 $svn_path = preg_replace('/!svn\/rvr\/\d+\//', '', $svn_path);
+$svn_path = preg_replace('/!svn\/txr\/\d+-[\d\w]+\//', '', $svn_path);
+$svn_path = preg_replace('/!svn\/txn\/\d+-[\d\w]+\//', '', $svn_path); // for some reason this does not do it during MERGE but the line above (which is the same except a single letter) does during other methods
 
 // special WebDAV URIs
 // https://svn.apache.org/repos/asf/subversion/trunk/notes/http-and-webdav/http-protocol-v2.txt


### PR DESCRIPTION
Without `PROPPATCH`, properties (such as `authz:read`) could be modified without having `authz:write` permissions.